### PR TITLE
Moving the shared library build files into submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Uncomment this and rebuild artifacts to enable debugging
+set(CMAKE_BUILD_TYPE Debug)
+
+project(petbmi VERSION 1.0.0 DESCRIPTION "OWP PET BMI Module Shared Library")
+
+# PET
+set(PET_LIB_NAME_CMAKE petbmi)
+set(PET_LIB_DESC_CMAKE "OWP PET BMI Module Shared Library")
+
+# Make sure these are compiled with this directive
+add_compile_definitions(BMI_ACTIVE)
+
+if(WIN32)
+    add_library(petbmi src/bmi_pet.c src/pet.c)
+else()
+    add_library(petbmi SHARED src/bmi_pet.c src/pet.c)
+endif()
+
+target_include_directories(petbmi PRIVATE include)
+
+set_target_properties(petbmi PROPERTIES VERSION ${PROJECT_VERSION})
+
+set_target_properties(petbmi PROPERTIES PUBLIC_HEADER bmi_pet.h)
+
+include(GNUInstallDirs)
+
+install(TARGETS petbmi
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+configure_file(petbmi.pc.in petbmi.pc @ONLY)
+
+install(FILES ${CMAKE_BINARY_DIR}/petbmi.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,17 @@
-# Installation instructions
+# PET Submodule Library Build Instructions
 
-Detailed instructions on how to install, configure, and get the project running.
+First, cd into the outer directory containing the submodule:
+
+    cd extern/evapotranspiration/evapotranspiration
+
+Before library files can be built, a CMake build system must be generated.  E.g.:
+
+    cmake -B cmake_build -S .
+
+Note that when there is an existing directory, it may sometimes be necessary to clear it and regenerate, especially if any changes were made to the [CMakeLists.txt](CMakeLists.txt) file.
+
+After there is build system directory, the shared library can be built using the `petbmi` CMake target. For example, the PET shared library file (i.e., the build config's `petbmi` target) can be built using:
+
+    cmake --build cmake_build --target petbmi -- -j 2
+
+This will build a `cmake_build/libpetbmi.<version>.<ext>` file, where the version is configured within the CMake config, and the extension depends on the local machine's operating system.    

--- a/petbmi.pc.in
+++ b/petbmi.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PET_LIB_NAME_CMAKE@
+Description: @PET_LIB_DESC_CMAKE@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lmylib
+Cflags: -I${includedir}


### PR DESCRIPTION
The goal here is to make the submodule more self contained and less affected by changes in ngen framework. 

## Additions

CMakeLists.txt
petbmi.pc.in

## Removals

-

## Changes

INSTALL.md

## Testing

1. Build the shared library locally.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x ] Linux
- [ ] Browser

### Accessibility

- [x] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [x ] Is useable without CSS
- [ x] Is useable without JS
- [ ] Flexible from small to large screens
- [x ] No linting errors or warnings
- [ ] JavaScript tests are passing
