### PR TITLE
Fix negative PET

### DIFF
--- a/src/pet.c
+++ b/src/pet.c
@@ -129,6 +129,7 @@ extern int run_pet(pet_model* model)
   if(model->pet_options.use_penman_monteith_method ==1)
     model->pet_m_per_s=pevapotranspiration_penman_monteith_method(model);
 
+  // prevent dew from forming (i.e., PET < 0)
   if(model->pet_m_per_s<0) {
     model->pet_m_per_s = 0;
   }

--- a/src/pet.c
+++ b/src/pet.c
@@ -129,6 +129,10 @@ extern int run_pet(pet_model* model)
   if(model->pet_options.use_penman_monteith_method ==1)
     model->pet_m_per_s=pevapotranspiration_penman_monteith_method(model);
 
+  if(model->pet_m_per_s<0) {
+    model->pet_m_per_s = 0;
+  }
+
   if (model->bmi.verbose >=1){
     printf("\n");
     printf("_______________________________________________________________________________\n");


### PR DESCRIPTION
Fix negative PET due to negative net radiation over night.  Set's PET to `0` when negative.

## Testing

1. [make_and_run_pass_forcings.sh](https://github.com/NOAA-OWP/evapotranspiration/blob/master/make_and_run_pass_forcings.sh)
2. [make_and_run_read_forcings.sh](https://github.com/NOAA-OWP/evapotranspiration/blob/master/make_and_run_read_forcings.sh)

## Notes

Fix was originally addressed in PET routine in separate CFE repo [here](https://github.com/NOAA-OWP/cfe/commit/8b02fdd6e619e3540100806c1d42a892dd8aea28).
