### PR TITLE
Update BMI spec to remove precipitation

### DIFF
--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -5,7 +5,7 @@
 #include "../include/bmi.h"
 #include "../include/bmi_pet.h"
 
-#define INPUT_VAR_NAME_COUNT 8 // All the forcings? 
+#define INPUT_VAR_NAME_COUNT 7 //
 #define OUTPUT_VAR_NAME_COUNT 1 // water_potential_evaporation_flux; 
 
 static int 
@@ -355,7 +355,6 @@ static const int input_var_item_count[INPUT_VAR_NAME_COUNT] = {
   1,
   1,
   1,
-  1,
   1
 };
 
@@ -367,13 +366,11 @@ static const char input_var_grids[INPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
-        0,
         0
 };
 
 //---------------------------------------------------------------------------------------------------------------------
 static const char *input_var_locations[INPUT_VAR_NAME_COUNT] = {
-        "node",
         "node",
         "node",
         "node",
@@ -393,7 +390,6 @@ static const char *input_var_names[INPUT_VAR_NAME_COUNT] = {
     "land_surface_radiation~incoming~longwave__energy_flux",
     "land_surface_air__pressure",
     "atmosphere_air_water~vapor__relative_saturation",
-    "atmosphere_water__liquid_equivalent_precipitation_rate",
     "land_surface_radiation~incoming~shortwave__energy_flux",
     "land_surface_air__temperature",
     "land_surface_wind__x_component_of_velocity",
@@ -408,7 +404,6 @@ static const char *input_var_types[INPUT_VAR_NAME_COUNT] = {
   "double",
   "double",
   "double",
-  "double",
   "double"
 };
 
@@ -417,7 +412,6 @@ static const char *input_var_units[INPUT_VAR_NAME_COUNT] = {
   "W m-2",
   "Pa",
   "kg kg-1",
-  "kg m-2",
   "W m-2",
   "K",
   "m s-1",
@@ -885,13 +879,6 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         pet_model *pet;
         pet = (pet_model *) self->data;
         src = (void*)&pet->aorc.specific_humidity_2m_kg_per_kg;
-        *dest = src;
-        return BMI_SUCCESS;
-    }
-    if (strcmp (name, "atmosphere_water__liquid_equivalent_precipitation_rate") == 0) {
-        pet_model *pet;
-        pet = (pet_model *) self->data;
-        src = (void*)&pet->aorc.precip_kg_per_m2;
         *dest = src;
         return BMI_SUCCESS;
     }

--- a/src/main_pass_forcing.c
+++ b/src/main_pass_forcing.c
@@ -36,10 +36,6 @@ void pass_forcing_from_aorc_to_pet(Bmi *pet_bmi_model, Bmi *aorc_bmi_model){
     aorc_bmi_model->get_value(aorc_bmi_model, var_name3, &(var[0]));
     pet_bmi_model->set_value(pet_bmi_model, var_name3, &(var[0]));
 
-    const char* var_name4 = "atmosphere_water__liquid_equivalent_precipitation_rate";
-    aorc_bmi_model->get_value(aorc_bmi_model, var_name4, &(var[0]));
-    pet_bmi_model->set_value(pet_bmi_model, var_name4, &(var[0]));
-
     const char* var_name5 = "land_surface_radiation~incoming~shortwave__energy_flux";
     aorc_bmi_model->get_value(aorc_bmi_model, var_name5, &(var[0]));
     pet_bmi_model->set_value(pet_bmi_model, var_name5, &(var[0]));
@@ -132,7 +128,6 @@ int
     pet_bmi_model->update(pet_bmi_model);
     printf("LWDOWN after set value %lf\n", pet->aorc.incoming_longwave_W_per_m2);
     printf("SWDOWN before set value %lf\n", pet->aorc.incoming_shortwave_W_per_m2);
-    printf("precip_kg_per_m2 %lf \n", pet->aorc.precip_kg_per_m2);
     printf("surface_pressure_Pa %lf \n", pet->aorc.surface_pressure_Pa);
     printf("specific_humidity_2m_kg_per_kg %lf \n", pet->aorc.specific_humidity_2m_kg_per_kg);
     printf("air_temperature_2m_K %lf \n", pet->aorc.air_temperature_2m_K);

--- a/src/main_read_forcing.c
+++ b/src/main_read_forcing.c
@@ -1,4 +1,4 @@
-#include <stdio.h>
+ #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include "../include/bmi.h"
@@ -61,7 +61,6 @@ int
       pet_bmi_model->update(pet_bmi_model);
       printf("LWDOWN after set value %lf\n", pet->aorc.incoming_longwave_W_per_m2);
       printf("SWDOWN before set value %lf\n", pet->aorc.incoming_shortwave_W_per_m2);
-      printf("precip_kg_per_m2 %lf \n", pet->aorc.precip_kg_per_m2);
       printf("surface_pressure_Pa %lf \n", pet->aorc.surface_pressure_Pa);
       printf("specific_humidity_2m_kg_per_kg %lf \n", pet->aorc.specific_humidity_2m_kg_per_kg);
       printf("air_temperature_2m_K %lf \n", pet->aorc.air_temperature_2m_K);


### PR DESCRIPTION
## Removals

- Removed `atmosphere_water__liquid_equivalent_precipitation_rate` from list of `input_vars`

## Changes

- Changed the number of `input_vars` from 8 to 7
- Updated BMI functions accordingly

## Testing

1. Ran PET code and unit tests

## Todos

- Should we modify structs to remove all potential to read in/store precipitation data? Would be more intensive than just modifying the BMI specification.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [ ] Linux
- [x] MacOS