### PR TITLE
require c99 standard compiler to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set_target_properties(petbmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 set_target_properties(petbmi PROPERTIES PUBLIC_HEADER bmi_pet.h)
 
+# Code requires minimum of C99 standard to compile
+set_target_properties(petbmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)
+
 include(GNUInstallDirs)
 
 install(TARGETS petbmi


### PR DESCRIPTION
cmake builds may fail with compilers that default to older C standards.
There are several loops in the code with the following structure:

```C
for( int i = 0; i < INPUT_VAR_NAME_COUNT; i++){

}
```

This is illegal syntax in C standards prior to 99, and would require each of these loops to be re-written as such

```C
int i = 0;
for( i = 0; i < INPUT_VAR_NAME_COUNT; i++){

}
```

I don't think in 2022 it is unreasonable to simply require a C compiler that supports the C99 standard that allows the first syntax to work as intended.  This PR simply forces CMake to pass the `--std=C99` to the complier to ensure the build will pass for any compiler that supports a `--std` flag.


## Changes

- Make C99 standard required for building the library.

## Testing

1. Tested the configuration and build using gcc 4.8.5

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] MacOS
- [x] Linux
