### PR TITLE
Wwu dev2

### DIFF
--- a/include/PEtPenmanMonteithMethod.h
+++ b/include/PEtPenmanMonteithMethod.h
@@ -92,8 +92,9 @@ double penman_monteith_pet_calculation
   }
   
   // use approximations from UN FAO: http://www.fao.org/3/X0490E/x0490e06.htm#aerodynamic%20resistance%20(ra)
-  model->pet_params.zero_plane_displacement_height_m=2.0/3.0*model->pet_params.vegetation_height_m;
-  model->pet_params.momentum_transfer_roughness_length_m=0.123*model->pet_params.vegetation_height_m;
+  //model->pet_params.zero_plane_displacement_height_m=2.0/3.0*model->pet_params.vegetation_height_m; //wwu
+  //model->pet_params.momentum_transfer_roughness_length_m=0.123*model->pet_params.vegetation_height_m; //wwu
+  model->pet_params.momentum_transfer_roughness_length_m=0.1845*model->pet_params.zero_plane_displacement_height_m; //wwu 
   model->pet_params.heat_transfer_roughness_length_m=0.1*model->pet_params.momentum_transfer_roughness_length_m;
 
   aerodynamic_resistance_s_per_m = calculate_aerodynamic_resistance(model);

--- a/include/PEtPenmanMonteithMethod.h
+++ b/include/PEtPenmanMonteithMethod.h
@@ -94,7 +94,7 @@ double penman_monteith_pet_calculation
   // use approximations from UN FAO: http://www.fao.org/3/X0490E/x0490e06.htm#aerodynamic%20resistance%20(ra)
   model->pet_params.zero_plane_displacement_height_m=2.0/3.0*model->pet_params.vegetation_height_m;
   model->pet_params.momentum_transfer_roughness_length_m=0.123*model->pet_params.vegetation_height_m;
-  model->pet_params.heat_transfer_roughness_length_m=0.1*model->pet_params.vegetation_height_m;
+  model->pet_params.heat_transfer_roughness_length_m=0.1*model->pet_params.momentum_transfer_roughness_length_m;
 
   aerodynamic_resistance_s_per_m = calculate_aerodynamic_resistance(model);
 

--- a/include/pet_tools.h
+++ b/include/pet_tools.h
@@ -140,7 +140,12 @@ double calculate_aerodynamic_resistance(pet_model *model)
   uz=wind_speed_m_per_s;
 
   // here log is the natural logarithm.
-
+  // add a necessary condition for ra calculation 
+  // TODO: check zero displacement height (parsing from config_file?)
+  if (d >= zh) {
+    d = 2.0/3.0 * zh;
+  }
+  
   ra=log((zm-d)/zom)*log((zh-d)/zoh)/(von_karman_constant_squared*uz);  // this is the equation for the aero. resist.
                                                                       // from the FAO reference PET document.
 


### PR DESCRIPTION
To fix the unrealistically large values from PET module options 2, 3 and 5:
1. Commenting out the zero-plane displacement height (d) function of the vegetation (canopy) height (hc) so to input the d value directly from the config file;
2. Modifying the momentum-transfer roughness length (zom) from the function of hc to a function of d and keeping the heat-transfer roughness length (zoh) function of zom to accommodate the magnitude logic among the three parameters d, zom and zoh;
3. Recompile PET module and rebuilt ngen. 

## Additions
In the config file, after the d value is set, the zom and zoh can be set as "0", and the functions in the code will pick up the d value to compute zom and zoh.

## Removals
1. Commenting out the zero-plane displacement height function of the vegetation (canopy) height 
`//model->pet_params.zero_plane_displacement_height_m=2.0/3.0*model->pet_params.vegetation_height_m; `

## Changes
2. Modifying the momentum-transfer roughness length from the function of the vegetation height to a function of the zero-plane displacement height;
`//model->pet_params.momentum_transfer_roughness_length_m=0.123*model->pet_params.vegetation_height_m;`
`model->pet_params.momentum_transfer_roughness_length_m=0.1845*model->pet_params.zero_plane_displacement_height_m;`

## Testing

1. Start with d = 0.001 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
