### PR TITLE
Modify `update_until()` def 

### DIFF
--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -140,7 +140,48 @@ Update (Bmi *self)
     return BMI_SUCCESS;
 }
 
-static int
+// Implimenting a more standard version of update_until here...
+
+static int 
+Update_until (Bmi *self, double t)
+{
+    // https://bmi.readthedocs.io/en/latest/#update-until
+    // "the time argument can be a non-integral multiple of time steps"
+
+    pet_model* pet = (pet_model *) self->data;
+    
+    double dt;
+    double now;
+
+    if(self->get_time_step (self, &dt) == BMI_FAILURE)
+        return BMI_FAILURE;
+
+    if(self->get_current_time(self, &now) == BMI_FAILURE)
+        return BMI_FAILURE;    
+
+    {
+    
+    int n;
+    double frac;
+    const double n_steps = (t - now) / dt;
+    for (n=0; n<(int)n_steps; n++) {
+        Update (self);
+    }
+    frac = n_steps - (int)n_steps;
+    if (frac > 0){
+        printf("WARNING: PET trying to update a fraction of a timestep\n");
+        
+        // change timestep to remaining fraction & call update()
+        pet->bmi.time_step_size_s = frac * dt;
+        Update (self);
+        pet->bmi.time_step_size_s = dt;
+    }
+
+    }
+
+  return BMI_SUCCESS;
+}
+/*static int
 Update_until(Bmi *self, double t)
 {
 
@@ -280,7 +321,8 @@ Update_until(Bmi *self, double t)
     // If we arrive here, t wasn't an exact time at end of a time step or a valid relative time step jump, so invalid.
     return BMI_FAILURE;
     
-}
+}*/
+
 
 pet_model *
 new_bmi_pet()

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -140,7 +140,7 @@ Update (Bmi *self)
     return BMI_SUCCESS;
 }
 
-// Implimenting a more standard version of update_until here...
+// JLG: Implimenting a more standard version of update_until here...
 
 static int 
 Update_until (Bmi *self, double t)

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -390,7 +390,7 @@ main(int argc, const char *argv[]){
         int added_nstep=5;
         int total_nstep= added_nstep + test_nstep;
         printf("\n updating until... new total timesteps in test loop: %i\n", total_nstep);
-        status = model->update_until(model,total_nstep);
+        status = model->update_until(model,total_nstep*dt);
         if (status == BMI_FAILURE) return BMI_FAILURE;
         // confirm updated current time
         model->get_current_time(model, &now);


### PR DESCRIPTION
The current version of `update_until()` includes a lot of temporary debug print statements.  Not 100% sure if it's fully functional as is. Recommend a more standard approach, similar to CFE, etc. 

//TODO: confirm the fractional input is valid?  Are we supporting this aspect for the `update_until()` call, or is this functionality optional? 

```
    frac = n_steps - (int)n_steps;
    if (frac > 0){
        printf("WARNING: PET trying to update a fraction of a timestep\n");
        
        // change timestep to remaining fraction & call update()
        pet->bmi.time_step_size_s = frac * dt;
        Update (self);
        pet->bmi.time_step_size_s = dt;
    }
```

