### PR TITLE
fix two file resource leaks

### DIFF
--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -113,6 +113,7 @@ Initialize (Bmi *self, const char *cfg_file)
             if (i == 0)
                 pet->bmi.current_time =forcings.time;
         }
+        fclose(ffp):
     }
 
     // Set the current time step to the first idem in the forcing time series.
@@ -772,7 +773,7 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
         }
 
     } // end loop through config
-
+    fclose(fp);
     return BMI_SUCCESS;
 } // end: read_init_config
 


### PR DESCRIPTION
Two cases where files are open (init config and forcing file) but were not closed.  When used as a library and applied to a lot of basins, this exhausts the available file handles unnecessarily.