### PR TITLE
Error cleanup

### DIFF
--- a/include/pet_tools.h
+++ b/include/pet_tools.h
@@ -243,7 +243,7 @@ void calculate_solar_radiation(pet_model* model)
   double optical_air_mass;
 
   int pet_doy = model->surf_rad_forcing.day_of_year;
-  int pet_zulu_time = model->surf_rad_forcing.zulu_time;
+  double pet_zulu_time = model->surf_rad_forcing.zulu_time;
 
   solar_constant_W_per_sq_m = 1361.6;     // Dudock de Wit et al. 2017 GRL, approx. avg. value
 

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -700,6 +700,14 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
             }
             continue;
         }
+        if (strcmp(param_key, "heat_transfer_roughness_length_m") == 0) {
+            model->pet_params.heat_transfer_roughness_length_m = strtod(param_value, NULL);
+            if(model->bmi.verbose >=2){
+                printf("heat_transfer_roughness_length_m from config file \n");
+                printf("%lf\n", model->pet_params.heat_transfer_roughness_length_m);
+            }
+            continue;
+        }
         if (strcmp(param_key, "surface_longwave_emissivity") == 0) {
             model->surf_rad_params.surface_longwave_emissivity = strtod(param_value, NULL);
             if(model->bmi.verbose >=2){

--- a/src/pet.c
+++ b/src/pet.c
@@ -267,17 +267,19 @@ void pet_setup(pet_model* model)
 void pet_unit_tests(pet_model* model)
 {
   printf("\n #----------- BEGIN UNIT TESTS   ---------------# \n");
-  
+  printf("\n # Solar calcs assume LAT & LON from ./configs/pet_config_cat_67.txt# \n");
+  printf("\n # And that pet_doy = 208 & pet_zulu_time = 20.567\n");
+
   printf("\n #-----------       UNIT TEST    ---------------# \n");
-  printf("solar elevation angle is %lf degrees,\n and should be: 43.29101185 degrees \n",
+  printf("solar elevation angle is %lf degrees,\n and should be: 43.168329 degrees \n",
       model->solar_results.solar_elevation_angle_degrees);
   
   printf("\n #-----------       UNIT TEST    ---------------# \n");
-  printf("solar azimuth angle is %lf degrees,\n and should be: 225.06371958 degrees \n",
+  printf("solar azimuth angle is %lf degrees,\n and should be: 224.010087 degrees \n",
       model->solar_results.solar_azimuth_angle_degrees);
   
   printf("\n #-----------       UNIT TEST    ---------------# \n");
-  printf("solar local hour angle is %lf degrees,\n and should be: 31.01549773 degrees \n",
+  printf("solar local hour angle is %lf degrees,\n and should be: 30.447448 degrees \n",
       model->solar_results.solar_local_hour_angle_degrees);
   printf("\n #-----------       UNIT TEST    ---------------# \n");
   if (model->pet_options.use_energy_balance_method == 1)
@@ -289,7 +291,7 @@ void pet_unit_tests(pet_model* model)
   if (model->pet_options.use_priestley_taylor_method == 1)
       printf("potential ET is %8.6e m/s,\n and should be: 8.249098e-08 m/s \n", model->pet_m_per_s);
   if (model->pet_options.use_penman_monteith_method == 1)
-      printf("potential ET is %8.6e m/s,\n and should be: 1.106268e-08 m/s \n", model->pet_m_per_s);
+      printf("potential ET is %8.6e m/s,\n and should be: 7.628671e-08 m/s \n", model->pet_m_per_s);
 
   printf("\n #------------  END UNIT TESTS   ---------------# \n");
   printf("\n");


### PR DESCRIPTION
Issue #26 notes that the unit test values hard-coded into the PET routines don't match the values computed by the model. I found two reasons for this:

1. The `pet_zulu_time` var was set to be an `int` but it's a `double`
2. The assumed latitude and longitude were incorrect

Additionally, issue #27 found an uninitialized parameter.

Both issues are now fixed.

## Additions

- NONE

## Removals

- NONE

## Changes

- `src/pet.c` Updated print statements with correct values for lat & lon
- `include/pet_tools.h` Changed `pet_zulu_time` from `int` to `double`
- `src/bmi_pet.c` Updated to include `heat_transfer_roughness_length_m` initialization

## Testing

1. Ran `./make_and_run_read_forcings.sh`



Closes #26 and #27

