### PR TITLE
Required updates for integration workflow

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -52,6 +52,7 @@ jobs:
         with:
           mod-dir: " extern/noah-owp-modular/"
           targets: "surfacebmi"
+          cmake-flags: "-DNGEN_IS_MAIN_PROJECT:BOOL=ON"
 
       - name: Build ISO C Fortran BMI
         id: submod_build_2
@@ -97,6 +98,7 @@ jobs:
         with:
           mod-dir: "extern/evapotranspiration/evapotranspiration"
           targets: "petbmi"
+          initialize: "false"
 
       - name: Run Ngen Test with PET
         run: |


### PR DESCRIPTION
Includes two fixes to `ngen_integration.yaml` workflow
1. Passes cmake build flag `-DNGEN_IS_MAIN_PROJECT:BOOL=ON` to NOM lib build
2. Set's PET submodule initialize build to `false`.  This allows for actual updates in PRs to be tested.  Otherwise, the specific master branch commit pinned in `ngen`'s `extern/evapotranspiration` will overwrite any local code changes copied to the model's working directory. 

See relevant discussions [here](https://github.com/NOAA-OWP/noah-owp-modular/pull/105) and [here](https://github.com/NOAA-OWP/ngen/pull/769).
## Testing

1. All workflows passed in manual action runs.  See [job details](https://github.com/NOAA-OWP/evapotranspiration/actions/runs/8364027850). 


