### PR TITLE
Fix mistaken non-calls to exit()

### DIFF
--- a/src/pet.c
+++ b/src/pet.c
@@ -430,7 +430,7 @@ void itwo_alloc_pet(int ***array, int rows, int cols) {
 
     if ((rows == 0) || (cols == 0)) {
         printf("Error: Attempting to allocate array of size 0\n");
-        exit;
+        exit(1);
     }
 
     frows = rows + 1;  /* added one for FORTRAN numbering */
@@ -459,7 +459,7 @@ void dtwo_alloc_pet(double ***array, int rows, int cols) {
 
     if ((rows == 0) || (cols == 0)) {
         printf("Error: Attempting to allocate array of size 0\n");
-        exit;
+        exit(1);
     }
 
     frows = rows + 1;  /* added one for FORTRAN numbering */


### PR DESCRIPTION
In C, `exit;` is not an effective statement - it just evaluates the pointer to the function `exit()`, rather than calling it. This was probably a relic of porting code from Fortran. I noticed a compiler warning about this.

## Changes

- Actually call `exit()` instead of just referencing it

## Testing

This is in error handling code, which is not tested (AFAIK)

## Screenshots

```
[  7%] Building C object /repos/ngen/extern/evapotranspiration/evapotranspiration/cmake_build/CMakeFiles/petbmi.dir/src/pet.c.o
/repos/ngen/extern/evapotranspiration/evapotranspiration/src/pet.c:433:9: warning: expression result unused [-Wunused-value]
        exit;
        ^~~~
/repos/ngen/extern/evapotranspiration/evapotranspiration/src/pet.c:462:9: warning: expression result unused [-Wunused-value]
        exit;
        ^~~~
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
