### PR TITLE
Fix warnings to support -Werror in Github CI

### DIFF
--- a/make_and_run_pass_forcings.sh
+++ b/make_and_run_pass_forcings.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-gcc ./src/main_pass_forcing.c ./src/pet.c ./src/bmi_pet.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -lm -o run_bmi_forcings_pass
+gcc -Werror ./src/main_pass_forcing.c ./src/pet.c ./src/bmi_pet.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -lm -o run_bmi_forcings_pass
 ./run_bmi_forcings_pass ./configs/pet_config_bmi.txt ./configs/aorc_config_cat_67.txt 

--- a/make_and_run_pass_forcings.sh
+++ b/make_and_run_pass_forcings.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-gcc -Werror ./src/main_pass_forcing.c ./src/pet.c ./src/bmi_pet.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -lm -o run_bmi_forcings_pass
+gcc ./src/main_pass_forcing.c ./src/pet.c ./src/bmi_pet.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -lm -o run_bmi_forcings_pass
 ./run_bmi_forcings_pass ./configs/pet_config_bmi.txt ./configs/aorc_config_cat_67.txt 

--- a/make_and_run_read_forcings.sh
+++ b/make_and_run_read_forcings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-gcc ./src/main_read_forcing.c ./src/pet.c ./src/bmi_pet.c -lm -o run_bmi_forcings_read
+gcc -Werror ./src/main_read_forcing.c ./src/pet.c ./src/bmi_pet.c -lm -o run_bmi_forcings_read
 ./run_bmi_forcings_read ./configs/pet_config_unit_test1.txt 
 ./run_bmi_forcings_read ./configs/pet_config_unit_test2.txt 
 ./run_bmi_forcings_read ./configs/pet_config_unit_test3.txt 

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -769,7 +769,7 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
             model->bmi.time_step_size_s = strtod(param_value, NULL);
             if(model->bmi.verbose >=2){
                 printf("time_step_size_s from config file \n");
-                printf("%ld\n", model->bmi.time_step_size_s);
+                printf("%d\n", model->bmi.time_step_size_s);
             }
             continue;
         }
@@ -777,7 +777,7 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
             model->bmi.num_timesteps = strtod(param_value, NULL);
             if(model->bmi.verbose >=2){
                 printf("num_timesteps from config file \n");
-                printf("%d\n", model->bmi.num_timesteps);
+                printf("%ld\n", model->bmi.num_timesteps);
             }
             continue;
         }

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -73,15 +73,20 @@ Initialize (Bmi *self, const char *cfg_file)
         char line_str[max_forcing_line_length + 1];
         long year, month, day, hour, minute;
         double dsec;
+        char* ret = NULL;
         // First read the header line
-        fgets(line_str, max_forcing_line_length + 1, ffp);
-    
+        ret = fgets(line_str, max_forcing_line_length + 1, ffp);
+        if (ret == NULL)
+            return BMI_FAILURE;
+
         if (pet->bmi.verbose > 2) 
             printf("the number of time steps from the forcing file is: %8.6e \n", (double)pet->bmi.num_timesteps);
     
         aorc_forcing_data_pet forcings;
         for (int i = 0; i < pet->bmi.num_timesteps; i++) {
-            fgets(line_str, max_forcing_line_length + 1, ffp);  // read in a line of AORC data.
+            ret = fgets(line_str, max_forcing_line_length + 1, ffp);  // read in a line of AORC data.
+            if (ret == NULL)
+                return BMI_FAILURE;
             parse_aorc_line_pet(line_str, &year, &month, &day, &hour, &minute, &dsec, &forcings);
             pet->forcing_data_precip_kg_per_m2[i] = forcings.precip_kg_per_m2 * ((double)pet->bmi.time_step_size_s);
             if (pet->bmi.verbose >4)
@@ -602,13 +607,17 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
     if (fp == NULL)
         return BMI_FAILURE;
 
+    char* ret = NULL;
+
     // TODO: document config file format (<param_key>=<param_val>, where array values are comma delim strings)
 
     char config_line[max_config_line_length + 1];
 
     for (int i = 0; i < config_line_count; i++) {
         char *param_key, *param_value;
-        fgets(config_line, max_config_line_length + 1, fp);
+        ret = fgets(config_line, max_config_line_length + 1, fp);
+        if (ret == NULL)
+            return BMI_FAILURE;
         char* config_line_ptr = config_line;
         config_line_ptr = strsep(&config_line_ptr, "\n");
         param_key = strsep(&config_line_ptr, "=");

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -77,7 +77,7 @@ Initialize (Bmi *self, const char *cfg_file)
         fgets(line_str, max_forcing_line_length + 1, ffp);
     
         if (pet->bmi.verbose > 2) 
-            printf("the number of time steps from the forcing file is: %8.6e \n", pet->bmi.num_timesteps);
+            printf("the number of time steps from the forcing file is: %8.6e \n", (double)pet->bmi.num_timesteps);
     
         aorc_forcing_data_pet forcings;
         for (int i = 0; i < pet->bmi.num_timesteps; i++) {
@@ -514,7 +514,7 @@ static int Get_current_time (Bmi *self, double * time)
 {
     Get_start_time(self, time);
     if (((pet_model *) self->data)->bmi.verbose > 2){
-        printf("Current model time step: '%ld'\n", ((pet_model *) self->data)->bmi.current_time_step);
+        printf("Current model time step: '%8.6e'\n", ((pet_model *) self->data)->bmi.current_time_step);
     }
     *time += (((pet_model *) self->data)->bmi.current_step * 
               ((pet_model *) self->data)->bmi.time_step_size_s);
@@ -760,7 +760,7 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
             model->bmi.time_step_size_s = strtod(param_value, NULL);
             if(model->bmi.verbose >=2){
                 printf("time_step_size_s from config file \n");
-                printf("%d\n", model->bmi.time_step_size_s);
+                printf("%ld\n", model->bmi.time_step_size_s);
             }
             continue;
         }

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -282,7 +282,7 @@ main(int argc, const char *argv[]){
             {
                 status = model->get_value_ptr(model, var_name, (void**)(&var));
                 if (status == BMI_FAILURE)return BMI_FAILURE;
-                printf("   get value ptr: %f\n",var);
+                printf("   get value ptr: %p\n",var);
             }
             // Go ahead and test set_value_*() for last time step here
             if (n == test_nstep){
@@ -346,7 +346,7 @@ main(int argc, const char *argv[]){
             {
                 status = model->get_value_ptr(model, var_name, (void**)(&var));
                 if (status == BMI_FAILURE)return BMI_FAILURE;
-                printf("   get value ptr: %f\n",var);
+                printf("   get value ptr: %p\n",var);
             }
             // Go ahead and test set_value_*() for last time step here
             if (n == test_nstep){

--- a/test/make_and_run_bmi_unit_test.sh
+++ b/test/make_and_run_bmi_unit_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-gcc ./main_unit_test_bmi.c ../src/bmi_pet.c ../src/pet.c -lm -o run_pet_bmi_test
+gcc -Werror ./main_unit_test_bmi.c ../src/bmi_pet.c ../src/pet.c -lm -o run_pet_bmi_test
 ./run_pet_bmi_test ../configs/pet_config_bmi_unit_test.txt
 #./run_pet_bmi_test ../configs/pet_config_cat_67.txt


### PR DESCRIPTION
## Changes

- Match `printf` format specifiers to argument types
- Check return values from `fgets`

## Testing

1. CI workflows

## Screenshots

This is what I was getting in ngen's CI workflows. More turned up in the rest of the codebase here

```
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c: In function ‘Initialize’:
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:80:76: error: format ‘%e’ expects argument of type ‘double’, but argument 2 has type ‘long int’ [-Werror=format=]
   80 |             printf("the number of time steps from the forcing file is: %8.6e \n", pet->bmi.num_timesteps);
      |                                                                        ~~~~^      ~~~~~~~~~~~~~~~~~~~~~~
      |                                                                            |              |
      |                                                                            double         long int
      |                                                                        %8.6ld
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c: In function ‘Get_current_time’:
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:517:45: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘double’ [-Werror=format=]
  517 |         printf("Current model time step: '%ld'\n", ((pet_model *) self->data)->bmi.current_time_step);
      |                                           ~~^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |                                     |
      |                                             long int                              double
      |                                           %f
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c: In function ‘read_init_config_pet’:
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:763:26: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘long int’ [-Werror=format=]
  763 |                 printf("%d\n", model->bmi.num_timesteps);
      |                         ~^     ~~~~~~~~~~~~~~~~~~~~~~~~
      |                          |               |
      |                          int             long int
      |                         %ld
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:611:9: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
  611 |         fgets(config_line, max_config_line_length + 1, fp);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c: In function ‘Initialize’:
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:77:9: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
   77 |         fgets(line_str, max_forcing_line_length + 1, ffp);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/evapotranspiration/evapotranspiration/src/bmi_pet.c:84:13: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
   84 |             fgets(line_str, max_forcing_line_length + 1, ffp);  // read in a line of AORC data.
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] macOS
