### PR TITLE
Guard against compiler warnings, second try

### DIFF
--- a/make_and_run_pass_forcings.sh
+++ b/make_and_run_pass_forcings.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+set -ex
+
 gcc ./src/main_pass_forcing.c ./src/pet.c ./src/bmi_pet.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -lm -o run_bmi_forcings_pass
 ./run_bmi_forcings_pass ./configs/pet_config_bmi.txt ./configs/aorc_config_cat_67.txt 

--- a/make_and_run_read_forcings.sh
+++ b/make_and_run_read_forcings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-gcc -Werror ./src/main_read_forcing.c ./src/pet.c ./src/bmi_pet.c -lm -o run_bmi_forcings_read
+gcc -Werror -Og ./src/main_read_forcing.c ./src/pet.c ./src/bmi_pet.c -lm -o run_bmi_forcings_read
 ./run_bmi_forcings_read ./configs/pet_config_unit_test1.txt 
 ./run_bmi_forcings_read ./configs/pet_config_unit_test2.txt 
 ./run_bmi_forcings_read ./configs/pet_config_unit_test3.txt 

--- a/make_and_run_read_forcings.sh
+++ b/make_and_run_read_forcings.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -ex
+
 gcc -Werror -Og ./src/main_read_forcing.c ./src/pet.c ./src/bmi_pet.c -lm -o run_bmi_forcings_read
 ./run_bmi_forcings_read ./configs/pet_config_unit_test1.txt 
 ./run_bmi_forcings_read ./configs/pet_config_unit_test2.txt 

--- a/test/make_and_run_bmi_unit_test.sh
+++ b/test/make_and_run_bmi_unit_test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -ex
+
 gcc -Werror -Og ./main_unit_test_bmi.c ../src/bmi_pet.c ../src/pet.c -lm -o run_pet_bmi_test
 ./run_pet_bmi_test ../configs/pet_config_bmi_unit_test.txt
 #./run_pet_bmi_test ../configs/pet_config_cat_67.txt

--- a/test/make_and_run_bmi_unit_test.sh
+++ b/test/make_and_run_bmi_unit_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-gcc -Werror ./main_unit_test_bmi.c ../src/bmi_pet.c ../src/pet.c -lm -o run_pet_bmi_test
+gcc -Werror -Og ./main_unit_test_bmi.c ../src/bmi_pet.c ../src/pet.c -lm -o run_pet_bmi_test
 ./run_pet_bmi_test ../configs/pet_config_bmi_unit_test.txt
 #./run_pet_bmi_test ../configs/pet_config_cat_67.txt


### PR DESCRIPTION
The compiler needs optimization flags to actually report the kinds of warnings we're looking for in ngen's CI.

Follow-on to #35 after I realized the above

## Changes

- Compile with minimal optimization to generate warnings that depend on control/data-flow analysis
- Make the shell scripts more particular about stopping on errors, rather than just letting them flow through.

## Testing

1. Local execution with GCC in a Linux VM
2. CI


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [ ] macOS
