### PR TITLE
Rename 'struct bmi' to not conflict with declarations from BMI headers

### DIFF
--- a/include/pet.h
+++ b/include/pet.h
@@ -211,7 +211,7 @@ struct intermediate_vars
   //double water_latent_heat_of_vaporization_J_per_kg;
   double psychrometric_constant_Pa_per_C;      // gamma
 };
-struct bmi
+struct pet_bmi
 {
   /*    
       JMFRAME: Fred suggested changing time step size to make the units of seconds explicit...
@@ -265,7 +265,7 @@ struct pet_model{
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_results    solar_results;
 
-  struct bmi bmi;
+  struct pet_bmi bmi;
 
 };
 typedef struct pet_model pet_model;


### PR DESCRIPTION
In service of NOAA-OWP/ngen#831, I encountered a name conflict between `struct bmi` here and `namespace bmi` from the BMI C++ header:

```
[ 31%] Building CXX object CMakeFiles/sft_pframework.dir/src/main_pseudo_framework.cxx.o
In file included from /home/runner/work/SoilFreezeThaw/SoilFreezeThaw/src/main_pseudo_framework.cxx:13:
/home/runner/work/SoilFreezeThaw/SoilFreezeThaw/extern/evapotranspiration/include/pet.h:214:8: error: ‘struct bmi’ redeclared as different kind of entity
  214 | struct bmi
      |        ^~~
In file included from /home/runner/work/SoilFreezeThaw/SoilFreezeThaw/src/main_pseudo_framework.cxx:5:
/home/runner/work/SoilFreezeThaw/SoilFreezeThaw/src/../bmi/bmi.hxx:13:11: note: previous declaration ‘namespace bmi { }’
   13 | namespace bmi {
      |           ^~~
```

We should not have things named simply `bmi` to avoid conflicts like this.

## Changes

- Rename `struct bmi` to `struct pet_bmi` and change the one instance of usage

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
