### PR TITLE
Ignore cmake_build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ run_bmi_forcings_pass
 run_bmi_forcings_read
 z_trash
 test/run_pet_bmi_test
+cmake_build/


### PR DESCRIPTION
The `cmake_build` directory in the ngen `extern/` submodule copy was making for noisy `git status` output when nothing has changed. It should be ignored.

## Changes

- Add `cmake_build` to `.gitignore`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: