### PR TITLE
Remove heat_transfer_roughness_length_m from psychrometric constant calculation

### DIFF
--- a/include/pet_tools.h
+++ b/include/pet_tools.h
@@ -456,8 +456,7 @@ void calculate_intermediate_variables(pet_model* model)
   // gamma
   water_latent_heat_of_vaporization_J_per_kg=2.501e+06-2370.0*model->pet_forcing.water_temperature_C;  // eqn 2.7.6 Chow etal.
                                                                                               // aka 'lambda'
-  psychrometric_constant_Pa_per_C=CP*model->pet_forcing.air_pressure_Pa*
-                                  model->pet_params.heat_transfer_roughness_length_m/
+  psychrometric_constant_Pa_per_C=CP*model->pet_forcing.air_pressure_Pa/
                                   (0.622*water_latent_heat_of_vaporization_J_per_kg);
   gamma=psychrometric_constant_Pa_per_C;
 


### PR DESCRIPTION
This removes the `heat_transfer_roughness_length_m` from the psychometric constant calculation. 

At small heat_transfer_roughness_length's this had a negligible effect on the PET calculations, but at higher heat_transfer_roughness_length's like those of forests, annual PET rates from methods 4 & 5 (Priestley-Taylor and Penman-Monteith) were many orders of magnitude greater than annual precipitation and published PET rates.

Heat transfer roughness length is calculated in the PET formulation from the zero_plane_displacement_height, which yields very small values for short vegetation and larger values for taller vegetation. 

## Additions

- 

## Removals

- Remove `heat_transfer_roughness_length_m` from the psychometric constant calculation

## Changes

- 

## Testing

1. 

## Screenshots



## Notes

- This breaks some of the unit tests that check the PET output values, if there is agreement that this change makes sense, I will submit a separate PR with new working tests.

## Todos

- Update and harden unit tests of PET outputs to account for a wider range of zero_plane_displacement_heights

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
