### PR TITLE
ci: fix macos runners

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -46,6 +46,20 @@ jobs:
         with:
           repository: noaa-owp/ngen
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Install python via uv
+        run: uv python install --default
+
+      - name: Install gcc12 on MacOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install gcc@12
+
       - name: Build Surfacebmi
         id: submod_build_1
         uses: ./.github/actions/ngen-submod-build
@@ -71,6 +85,7 @@ jobs:
         id: submod_build_6
         uses: ./.github/actions/ngen-submod-build
         with:
+          cmake-flags: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           mod-dir: "extern/sloth/"
           targets: "slothmodel"
 


### PR DESCRIPTION
install `gcc` / `gfortran` v12 on macos to align with compilers available on ubuntu runners.
appease sloth's cmake config w/ `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` flag.
pin `python==3.12` on OS runners.

supersedes #48