### PR TITLE
chore: don't hardcode `cmake` build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-# Uncomment this and rebuild artifacts to enable debugging
-set(CMAKE_BUILD_TYPE Debug)
-
 project(petbmi VERSION 1.0.0 DESCRIPTION "OWP PET BMI Module Shared Library")
 
 # PET


### PR DESCRIPTION
The build type should be configured in the cmake configuration stage w/ `DCMAKE_BUILD_TYPE=`.