### PR TITLE
fix: validate values that could cause divide by 0

### DIFF
--- a/include/pet_tools.h
+++ b/include/pet_tools.h
@@ -148,6 +148,12 @@ double calculate_aerodynamic_resistance(pet_model *model)
   if (d >= zh) {
     d = 2.0/3.0 * zh;
   }
+  if(zm != zh) {
+    // This check ensure the logs below are not zero and they are positive
+    // based on the displacement adjustment above.
+    fprintf(stderr,"ERROR: wind speed and humidity measurement heights differ in calculate_aerodynamic_resistance().\n");
+    exit(EXIT_FAILURE);
+  };
   
   ra=log((zm-d)/zom)*log((zh-d)/zoh)/(von_karman_constant_squared*uz);  // this is the equation for the aero. resist.
                                                                       // from the FAO reference PET document.

--- a/include/pet_tools.h
+++ b/include/pet_tools.h
@@ -131,8 +131,8 @@ double calculate_aerodynamic_resistance(pet_model *model)
   if(1.0e-06 >= heat_transfer_roughness_length_m )  //warn.  Should not be tiny.
     fprintf(stderr,"heat_transfer_roughness_length_m is tiny in calculate_aerodynamic_resistance().  Should not be tiny.\n");
   if(wind_speed_m_per_s <= 0.0 ) {
-    fprintf(stderr,"WARNING: wind_speed_m_per_s <= in calculate_aerodynamic_resistance(). Setting to 1e-6 m/s.\n");
-    wind_speed_m_per_s = 1e-6; // small positive value to avoid divide by zero
+    fprintf(stderr,"WARNING: wind_speed_m_per_s <= in calculate_aerodynamic_resistance(). Setting to 0.01 m/s.\n");
+    wind_speed_m_per_s = 0.01; // small positive value to avoid divide by zero
   }
   // convert to smaller local variable names to keep equation readable 
   zm=wind_speed_measurement_height_m;

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -161,7 +161,8 @@ Update_until (Bmi *self, double t)
 
     if(self->get_time_step (self, &dt) == BMI_FAILURE)
         return BMI_FAILURE;
-
+    if(dt == 0.0)
+        return BMI_FAILURE;
     if(self->get_current_time(self, &now) == BMI_FAILURE)
         return BMI_FAILURE;    
 

--- a/src/pet.c
+++ b/src/pet.c
@@ -66,7 +66,12 @@ extern int run_pet(pet_model* model)
   {
     if (model->bmi.verbose >1)
         printf("YES AORC \n");
-    
+    // Validate AORC humidity measurement height
+    if(model->pet_params.humidity_measurement_height_m !=2.0)
+    {
+        fprintf(stderr, "ERROR: humidity measurement height is not 2.0 m. Humidity adjustment not yet implemented. Current value: %lf\n", model->pet_params.humidity_measurement_height_m);
+        exit(EXIT_FAILURE);
+    }
     /* jmframe: If we are getting forcing through BMI, then we don't need this, the forcings should already be in place */
     if (model->bmi.is_forcing_from_bmi == 0){
       model->aorc.incoming_longwave_W_per_m2     =  model->forcing_data_incoming_longwave_W_per_m2[model->bmi.current_step];


### PR DESCRIPTION
Closes #52 by validating several config and/or forcing values which could lead to divide by zero situations.

## Changes

-  Prints to stderr and exists in most cases, but a default small wind_speed is used with a warning printed instead of a hard stop.

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
