### PR TITLE
Zero plane displacement clamp in BMI

### DIFF
--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -791,6 +791,24 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
 
     } // end loop through config
     fclose(fp);
+
+    // Validate parameters here if needed
+    if(model->pet_params.wind_speed_measurement_height_m < model->pet_params.zero_plane_displacement_height_m){
+        // This case is simply invalid and can't be handled gracefully...
+        printf("Error: wind speed measurement height must be greater than or equal to the zero plane displacement height. \n");
+        return BMI_FAILURE;
+    }
+    if (model->pet_params.zero_plane_displacement_height_m <= 0.0){
+        // if displacement height is 0 (or less for some unknown reason...)
+        // set to small value to avoid division by zero in wind profile equation
+        model->pet_params.zero_plane_displacement_height_m = 0.01;
+    }
+    if (model->pet_params.wind_speed_measurement_height_m == model->pet_params.zero_plane_displacement_height_m){
+        // avoid division by zero in wind profile equation when log(1) = 0
+        // compute the profile 1 mm below the measurement height
+        model->pet_params.zero_plane_displacement_height_m -= 0.01;
+    }
+
     return BMI_SUCCESS;
 } // end: read_init_config
 

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -793,20 +793,10 @@ int read_init_config_pet(pet_model* model, const char* config_file)//,
     fclose(fp);
 
     // Validate parameters here if needed
-    if(model->pet_params.wind_speed_measurement_height_m < model->pet_params.zero_plane_displacement_height_m){
-        // This case is simply invalid and can't be handled gracefully...
-        printf("Error: wind speed measurement height must be greater than or equal to the zero plane displacement height. \n");
-        return BMI_FAILURE;
-    }
     if (model->pet_params.zero_plane_displacement_height_m <= 0.0){
         // if displacement height is 0 (or less for some unknown reason...)
         // set to small value to avoid division by zero in wind profile equation
         model->pet_params.zero_plane_displacement_height_m = 0.01;
-    }
-    if (model->pet_params.wind_speed_measurement_height_m == model->pet_params.zero_plane_displacement_height_m){
-        // avoid division by zero in wind profile equation when log(1) = 0
-        // compute the profile 1 mm below the measurement height
-        model->pet_params.zero_plane_displacement_height_m -= 0.01;
     }
 
     return BMI_SUCCESS;


### PR DESCRIPTION
Related to #52 and #54 , when running the BMI model, we can try to prevent divide by zero conditions by clamping the zero plane displacement height.

## Additions

- Validate that measurement height is >= zero plane displacement height in user provided config
- Ensure that zero plane displacement is > 0 by setting it to 0.01 (1 mm) if it is 0 or less
- Ensure that zero plane displacement is < measurement height by setting it to `measurement height - 0.01` when they are equal.  This ensure valid computations of the profile at nearly the measurement height.


## Changes

- Config returns BMI_FAILURE and prints an error when measurement_height < displacement height

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

